### PR TITLE
generate https urls if running behind cloudfront

### DIFF
--- a/leg_tracker/leg_tracker/settings.py
+++ b/leg_tracker/leg_tracker/settings.py
@@ -120,3 +120,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static/")
+
+# generate https urls if running behind cloudfront
+# https://www.tibobeijen.nl/2017/10/26/django-https-urls-cloudfront/
+SECURE_PROXY_SSL_HEADER = ('HTTP_CLOUDFRONT_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
I've applied this change to the current instance, just need to merge this PR or apply this change in the repo so that it will survive if new instance is re-created.  Thanks